### PR TITLE
chore: Split CI to workaround GHA issue

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: sample-checks
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +25,40 @@ jobs:
       - name: Setup host
         uses: ./.github/actions/setup-host
       - name: Build
+        shell: bash
         run: npm run build
+      - name: Run integrations tests
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: npm run intTest
+      - name: Report to PR
+        uses: ./.
+        if: ${{ !cancelled() }}
+        with:
+          reports: |
+            lib/*-junit.xml
+      - name: Coverage report
+        uses: codecov/codecov-action@v5
+        if: ${{ !cancelled() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  sample-checks:
+    name: Sample Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup host
+        uses: ./.github/actions/setup-host
+      - name: Build
+        shell: bash
+        run: npm run compile && npm run package
       - name: Report to Check
         uses: ./.
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}
@@ -77,20 +111,3 @@ jobs:
           checkName: "Test Reports (GitHub App)"
           reports: |
             samples/
-      - name: Run integrations tests
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-        run: npm run intTest
-      - name: Report to PR
-        uses: ./.
-        if: ${{ !cancelled() }}
-        with:
-          reports: |
-            lib/*-junit.xml
-      - name: Coverage report
-        uses: codecov/codecov-action@v5
-        if: ${{ !cancelled() }}
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The issue https://github.com/actions/runner/issues/3462 seems to be impacting this CI.

After some research, I found that it seems to be related to the number of checks created using the `GitHub.token`.

After around 4/5, the check created by GHA itself seems to fail to update to a completed state.